### PR TITLE
Buy Together | Redis + Local 캐시

### DIFF
--- a/src/main/java/com/together/buytogether/cache/CacheConfig.java
+++ b/src/main/java/com/together/buytogether/cache/CacheConfig.java
@@ -1,0 +1,91 @@
+package com.together.buytogether.cache;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.together.buytogether.cache.manager.CompositeCacheManager;
+import com.together.buytogether.cache.manager.LocalCacheManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@EnableCaching
+@Slf4j
+public class CacheConfig {
+
+	private final RedisConnectionFactory redisConnectionFactory;
+
+	public CacheConfig(RedisConnectionFactory redisConnectionFactory) {
+		this.redisConnectionFactory = redisConnectionFactory;
+	}
+
+	@Bean(name = "localCacheManager")
+	public LocalCacheManager localCacheManager() {
+		log.info("로컬 초기화 시작");
+		List<Cache> caches = Arrays.stream(CacheName.values())
+			.filter(group ->
+				group.getCacheType() == CacheType.LOCAL ||
+					group.getCacheType() == CacheType.COMPOSITE
+			)
+			.map(this::toCaffeineCache)
+			.collect(Collectors.toList());
+		log.info("로컬 초기화 끝");
+
+		return new LocalCacheManager(caches);
+	}
+
+	private CaffeineCache toCaffeineCache(CacheName cacheName) {
+		return new CaffeineCache(
+			cacheName.getCacheName(),
+			Caffeine.newBuilder()
+				.expireAfterWrite(cacheName.getExpiredAfterWrite().getSeconds(), TimeUnit.SECONDS)
+				.recordStats()
+				.build()
+		);
+	}
+
+	@Bean(name = "redisCacheManager")
+	public RedisCacheManager redisCacheManager() {
+		RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.entryTtl(Duration.ofMinutes(30));
+		Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = Arrays.stream(CacheName.values())
+			.filter(it -> it.getCacheType() == CacheType.GLOBAL || it.getCacheType() == CacheType.COMPOSITE)
+			.collect(Collectors.toMap(
+				CacheName::getCacheName,
+				cacheName -> redisCacheConfiguration.entryTtl(cacheName.getExpiredAfterWrite())
+			));
+		return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+			.cacheDefaults(redisCacheConfiguration)
+			.withInitialCacheConfigurations(redisCacheConfigurationMap)
+			.build();
+	}
+
+	@Primary
+	@Bean
+	public CacheManager compositeCacheManager(CacheManager redisCacheManager,
+		LocalCacheManager localCacheManager) {
+		return new CompositeCacheManager(Arrays.asList(localCacheManager, redisCacheManager), localCacheManager);
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/CacheKey.java
+++ b/src/main/java/com/together/buytogether/cache/CacheKey.java
@@ -1,0 +1,10 @@
+package com.together.buytogether.cache;
+
+public final class CacheKey {
+
+	public static final String POSTS = "post_composite";
+	public static final String POSTS_REDIS = "post_redis";
+
+	private CacheKey() {
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/CacheName.java
+++ b/src/main/java/com/together/buytogether/cache/CacheName.java
@@ -1,0 +1,65 @@
+package com.together.buytogether.cache;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum CacheName {
+
+	POST_COMPOSITE_CACHE(
+		CacheKey.POSTS,
+		Duration.ofDays(1),
+		CacheType.COMPOSITE
+	),
+
+	POST_REDIS_CACHE(
+		CacheKey.POSTS_REDIS,
+		Duration.ofSeconds(20),
+		CacheType.GLOBAL
+	);
+
+	private static final Map<String, CacheName> CACHE_NAME_MAP;
+
+	static {
+		CACHE_NAME_MAP = Arrays.stream(CacheName.values())
+			.collect(Collectors.toMap(CacheName::getCacheName, Function.identity()));
+	}
+
+	private final String cacheName;
+	private final Duration expiredAfterWrite;
+	private final CacheType cacheType;
+
+	CacheName(String cacheName, Duration expiredAfterWrite, CacheType cacheType) {
+		this.cacheName = cacheName;
+		this.expiredAfterWrite = expiredAfterWrite;
+		this.cacheType = cacheType;
+	}
+
+	public static boolean isCompositeType(String cacheName) {
+		return get(cacheName).getCacheType() == CacheType.COMPOSITE;
+	}
+
+	private static CacheName get(String cacheName) {
+		CacheName foundCacheName = CACHE_NAME_MAP.get(cacheName);
+		if (foundCacheName == null) {
+			throw new NoSuchElementException(cacheName + " Cache Name Not Found");
+		}
+		return foundCacheName;
+	}
+
+	public String getCacheName() {
+		return cacheName;
+	}
+
+	public Duration getExpiredAfterWrite() {
+		return expiredAfterWrite;
+	}
+
+	public CacheType getCacheType() {
+		return cacheType;
+	}
+}
+

--- a/src/main/java/com/together/buytogether/cache/CacheType.java
+++ b/src/main/java/com/together/buytogether/cache/CacheType.java
@@ -1,0 +1,17 @@
+package com.together.buytogether.cache;
+
+public enum CacheType {
+	LOCAL("로컬 캐시만 사용"),
+	GLOBAL("글로벌 캐시만 사용"),
+	COMPOSITE("모두 사용");
+
+	private final String description;
+
+	CacheType(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/CompositeCache.java
+++ b/src/main/java/com/together/buytogether/cache/CompositeCache.java
@@ -1,0 +1,89 @@
+package com.together.buytogether.cache;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.Cache;
+
+import com.together.buytogether.cache.manager.UpdatableCacheManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CompositeCache implements Cache {
+
+	private final List<Cache> caches;
+	private final UpdatableCacheManager updatableCacheManager;
+
+	public CompositeCache(List<Cache> caches, UpdatableCacheManager updatableCacheManager) {
+		this.caches = caches;
+		this.updatableCacheManager = updatableCacheManager;
+	}
+
+	@Override
+	public String getName() {
+		return caches.get(0).getName();
+	}
+
+	@Override
+	public Object getNativeCache() {
+		return caches.stream()
+			.map(Cache::getNativeCache)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public ValueWrapper get(Object key) {
+		for (Cache cache : caches) {
+			ValueWrapper valueWrapper = cache.get(key);
+			if (valueWrapper != null && valueWrapper.get() != null) {
+				updatableCacheManager.putIfAbsent(cache, key, valueWrapper.get()); // L1 채우기
+				return valueWrapper;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public <T> T get(Object key, Class<T> type) {
+		for (Cache cache : caches) {
+
+		}
+		return null;
+	}
+
+	@Override
+	public <T> T get(Object key, Callable<T> valueLoader) {
+		for (Cache cache : caches) {
+			T value = cache.get(key, valueLoader);
+			if (value != null) {
+				updatableCacheManager.putIfAbsent(cache, key, value);
+				return value;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void put(Object key, Object value) {
+		for (Cache cache : caches) {
+			cache.put(key, value);
+		}
+	}
+
+	@Override
+	public void evict(Object key) {
+		for (Cache cache : caches) {
+			log.info("composite evict : {} ", cache.getName());
+			cache.evict(key);
+		}
+	}
+
+	@Override
+	public void clear() {
+		for (Cache cache : caches) {
+			cache.clear();
+		}
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/dto/CacheEvictMessage.java
+++ b/src/main/java/com/together/buytogether/cache/dto/CacheEvictMessage.java
@@ -1,0 +1,6 @@
+package com.together.buytogether.cache.dto;
+
+public record CacheEvictMessage(
+	String cacheName,
+	Object key) {
+}

--- a/src/main/java/com/together/buytogether/cache/event/RedisCacheEventPublisher.java
+++ b/src/main/java/com/together/buytogether/cache/event/RedisCacheEventPublisher.java
@@ -1,0 +1,29 @@
+package com.together.buytogether.cache.event;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.together.buytogether.cache.dto.CacheEvictMessage;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class RedisCacheEventPublisher {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public RedisCacheEventPublisher(final RedisTemplate<String, Object> redisTemplate, ObjectMapper objectMapper) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void publishEvict(String cacheName, Object key) {
+		CacheEvictMessage message = new CacheEvictMessage(cacheName, key);
+		publish(message);
+	}
+
+	public void publish(CacheEvictMessage message) {
+		redisTemplate.convertAndSend("CACHE_EVENT_CHANNEL", message);
+		log.info("Published cache event message: {}", message);
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/event/RedisCacheEventSubscriber.java
+++ b/src/main/java/com/together/buytogether/cache/event/RedisCacheEventSubscriber.java
@@ -1,0 +1,48 @@
+package com.together.buytogether.cache.event;
+
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.together.buytogether.cache.dto.CacheEvictMessage;
+import com.together.buytogether.cache.manager.LocalCacheManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RedisCacheEventSubscriber implements MessageListener {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final LocalCacheManager localCacheManager;
+	private final ObjectMapper objectMapper;
+
+	public RedisCacheEventSubscriber(
+		RedisTemplate<String, Object> redisTemplate,
+		LocalCacheManager localCacheManager,
+		ObjectMapper objectMapper) {
+		this.redisTemplate = redisTemplate;
+		this.localCacheManager = localCacheManager;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void onMessage(final Message message, final byte[] pattern) {
+		try {
+			CacheEvictMessage eventMessage = objectMapper.readValue(message.getBody(), CacheEvictMessage.class);
+			log.info("onMessage");
+			Cache cache = localCacheManager.getCache(eventMessage.cacheName());
+			if (cache == null) {
+				log.warn("Cache not found for name: {}", eventMessage.cacheName());
+				return;
+			}
+			cache.evict(eventMessage.key());
+			log.info("Evicted  cache '{}' for key: {}", eventMessage.cacheName(), eventMessage.key());
+
+		} catch (Exception e) {
+			log.error("Error while processing cache event message.", e);
+		}
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/manager/CompositeCacheManager.java
+++ b/src/main/java/com/together/buytogether/cache/manager/CompositeCacheManager.java
@@ -1,0 +1,59 @@
+package com.together.buytogether.cache.manager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import com.together.buytogether.cache.CacheName;
+import com.together.buytogether.cache.CompositeCache;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CompositeCacheManager implements CacheManager {
+
+	private final List<CacheManager> cacheManagers;
+	private final UpdatableCacheManager updatableCacheManager;
+	private final List<String> cacheNames;
+
+	public CompositeCacheManager(
+		List<CacheManager> cacheManagers,
+		UpdatableCacheManager updatableCacheManager) {
+		this.cacheManagers = new ArrayList<>(cacheManagers);
+		this.updatableCacheManager = updatableCacheManager;
+
+		List<String> names = new ArrayList<>();
+		for (CacheManager cacheManager : cacheManagers) {
+			names.addAll(cacheManager.getCacheNames());
+		}
+		this.cacheNames = names;
+	}
+
+	@Override
+	public Cache getCache(String name) {
+		if (CacheName.isCompositeType(name)) {
+			log.info("composite 캐시 조회");
+			List<Cache> caches = cacheManagers.stream()
+				.map(cacheManager -> cacheManager.getCache(name))
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
+			return new CompositeCache(caches, updatableCacheManager);
+		}
+
+		return cacheManagers.stream()
+			.map(cacheManager -> cacheManager.getCache(name))
+			.filter(Objects::nonNull)
+			.findFirst()
+			.orElse(null);
+	}
+
+	@Override
+	public List<String> getCacheNames() {
+		return new ArrayList<>(cacheNames);
+	}
+
+}

--- a/src/main/java/com/together/buytogether/cache/manager/LocalCacheManager.java
+++ b/src/main/java/com/together/buytogether/cache/manager/LocalCacheManager.java
@@ -1,0 +1,70 @@
+package com.together.buytogether.cache.manager;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LocalCacheManager implements CacheManager, UpdatableCacheManager {
+
+	private final Map<String, Cache> cacheMap = new ConcurrentHashMap<>();
+
+	public LocalCacheManager() {
+
+	}
+
+	public LocalCacheManager(List<Cache> caches) {
+		for (Cache cache : caches) {
+			cacheMap.put(cache.getName(), cache);
+		}
+	}
+
+	@Override
+	public Cache getCache(String name) {
+		log.info("로컬 캐시 조회 : {}", name);
+		return cacheMap.get(name);
+	}
+
+	public Collection<String> getCacheNames() {
+		return cacheMap.keySet();
+	}
+
+	@Override
+	public void putIfAbsent(Cache cache, Object key, Object value) {
+		Cache local = getCache(cache.getName());
+		if (local != null) {
+			local.putIfAbsent(key, value);
+		}
+	}
+
+	public Cache getOrCreateCache(String cacheName, Long timeToLiveMillis) {
+		return cacheMap.computeIfAbsent(cacheName, name -> {
+			log.info("새로운 로컬 캐시 생성: {} (TTL: {}ms)", name, timeToLiveMillis);
+
+			return new CaffeineCache(
+				name,
+				Caffeine.newBuilder()
+					.expireAfterWrite(Duration.ofMillis(timeToLiveMillis))
+					.recordStats()
+					.build()
+			);
+		});
+	}
+
+	public void putToCache(String cacheName, String key, Object value, Long timeToLiveMillis) {
+		Cache cache = getOrCreateCache(cacheName, timeToLiveMillis);
+		cache.put(key, value);
+		log.info("로컬 캐시 저장: {} -> {}", cacheName, key);
+	}
+
+}

--- a/src/main/java/com/together/buytogether/cache/manager/UpdatableCacheManager.java
+++ b/src/main/java/com/together/buytogether/cache/manager/UpdatableCacheManager.java
@@ -1,0 +1,7 @@
+package com.together.buytogether.cache.manager;
+
+import org.springframework.cache.Cache;
+
+public interface UpdatableCacheManager {
+	void putIfAbsent(Cache cache, Object key, Object value);
+}


### PR DESCRIPTION
게시글 조회 성능 향상을 위한 이중 캐시 도입


게시글 조회 API의 응답 속도를 개선하고, 데이터베이스(DB) 및 중앙 캐시(Redis)의 부하를 줄이기 위해 로컬 캐시와 Redis를 함께 사용하는 이중 캐시(Dual Cache) 구조를 도입합니다.

기존에는 모든 게시글 조회 요청이 DB로 직접 전달되었습니다. 이로 인해 사용자가 몰릴 경우 DB에 과도한 부하가 발생하여 전체 시스템의 안정성을 저해할 수 있는 잠재적 위험이 있었습니다.

실제 부하 테스트(1000개 스레드, 3분간 무작위 호출) 결과, 캐시를 적용하지 않았을 때의 처리량(TPS)은 약 254 TPS로 측정되었습니다.



단순히 Redis만 도입하는 것을 넘어, 시스템을 더 안정적으로 보호하기 위해 다음과 같은 단계로 개선을 진행했습니다.

    1차 접근: Redis 단일 캐시 도입

        분산 환경을 고려하여 Redis를 중앙 캐시로 우선 도입했습니다.

        그 결과 처리량은 457 TPS로 크게 향상되었습니다.

        문제점: 이 방식은 DB의 부하를 Redis로 옮기는 것일 뿐, 트래픽이 폭증할 경우 Redis 자체에 대한 과부하가 새로운 병목 지점이 될 수 있습니다.

    최종 해결책: 이중 캐시(Local Cache + Redis Cache) 구조 적용

        Redis의 부하를 최소화하고 응답 속도를 극대화하기 위해 각 애플리케이션 서버에 **로컬 캐시(L1 Cache)**를 추가했습니다.

        캐시 조회 순서는 다음과 같습니다.
        요청 → 로컬 캐시 확인 → (없으면) Redis 캐시 확인 → (없으면) DB 조회

        이 구조는 자주 조회되는 데이터를 각 서버가 직접 가지고 있게 하여 Redis로 향하는 트래픽을 획기적으로 줄여줍니다.