### PR TITLE
Buy Together - Single Flight Cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation "com.querydsl:querydsl-core"
     implementation "com.querydsl:querydsl-collections"
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
 
     //API 테스트 라이브러리

--- a/src/main/java/com/together/buytogether/annotation/SingleFlightCacheEvict.java
+++ b/src/main/java/com/together/buytogether/annotation/SingleFlightCacheEvict.java
@@ -1,0 +1,14 @@
+package com.together.buytogether.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SingleFlightCacheEvict {
+	String cacheName();
+
+	String key();
+}

--- a/src/main/java/com/together/buytogether/annotation/SingleFlightCacheable.java
+++ b/src/main/java/com/together/buytogether/annotation/SingleFlightCacheable.java
@@ -1,0 +1,23 @@
+package com.together.buytogether.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SingleFlightCacheable {
+	String cacheName();
+
+	String key();
+
+	long localTimeToLiveMillis();
+
+	long redisTimeToLiveMillis();
+
+	long decisionForUpdate() default 90;
+
+	long maxAttemptRefreshCache() default 1000;
+}
+

--- a/src/main/java/com/together/buytogether/aop/SingleFlightAspect.java
+++ b/src/main/java/com/together/buytogether/aop/SingleFlightAspect.java
@@ -1,0 +1,68 @@
+package com.together.buytogether.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import com.together.buytogether.annotation.SingleFlightCacheEvict;
+import com.together.buytogether.annotation.SingleFlightCacheable;
+import com.together.buytogether.cache.CacheKeyGenerator;
+import com.together.buytogether.cache.event.RedisCacheEventPublisher;
+import com.together.buytogether.cache.singleflight.CacheStrategyExecutor;
+import com.together.buytogether.cache.singleflight.SingleFlightCacheManager;
+
+@Aspect
+@Component
+public class SingleFlightAspect {
+
+	private final CacheKeyGenerator cacheKeyGenerator;
+	private final CacheStrategyExecutor cacheStrategyExecutor;
+	private final SingleFlightCacheManager singleFlightCacheManager;
+	private final RedisCacheEventPublisher redisCacheEventPublisher;
+
+	public SingleFlightAspect(CacheKeyGenerator cacheKeyGenerator,
+		CacheStrategyExecutor cacheStrategyExecutor,
+		SingleFlightCacheManager singleFlightCacheManager,
+		RedisCacheEventPublisher redisCacheEventPublisher) {
+		this.cacheKeyGenerator = cacheKeyGenerator;
+		this.cacheStrategyExecutor = cacheStrategyExecutor;
+		this.singleFlightCacheManager = singleFlightCacheManager;
+		this.redisCacheEventPublisher = redisCacheEventPublisher;
+	}
+
+	@Around("@annotation(com.together.buytogether.annotation.SingleFlightCacheable)")
+	public Object aroundSingleFlightCacheable(ProceedingJoinPoint joinPoint) throws Throwable {
+		SingleFlightCacheable annotation = getCacheableAnnotation(joinPoint);
+		String cacheKey = cacheKeyGenerator.generate(joinPoint, annotation.key(), annotation.cacheName());
+
+		return cacheStrategyExecutor.executeCacheStrategy(annotation, cacheKey, joinPoint);
+	}
+
+	@Around("@annotation(com.together.buytogether.annotation.SingleFlightCacheEvict)")
+	public Object aroundReqShieldCacheEvict(ProceedingJoinPoint joinPoint) throws Throwable {
+		SingleFlightCacheEvict annotation = getCacheEvictAnnotation(joinPoint);
+		String cacheKey = cacheKeyGenerator.generate(joinPoint, annotation.key(), annotation.cacheName());
+
+		singleFlightCacheManager.evictFromLocal(annotation.cacheName(), cacheKey);
+		singleFlightCacheManager.evictFromRedis(cacheKey);
+
+		redisCacheEventPublisher.publishEvict(annotation.cacheName(), cacheKey);
+		return joinPoint.proceed();
+	}
+
+	private SingleFlightCacheable getCacheableAnnotation(ProceedingJoinPoint joinPoint) {
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
+		Method method = methodSignature.getMethod();
+		return method.getAnnotation(SingleFlightCacheable.class);
+	}
+
+	private SingleFlightCacheEvict getCacheEvictAnnotation(ProceedingJoinPoint joinPoint) {
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
+		Method method = methodSignature.getMethod();
+		return method.getAnnotation(SingleFlightCacheEvict.class);
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/CacheKeyGenerator.java
+++ b/src/main/java/com/together/buytogether/cache/CacheKeyGenerator.java
@@ -1,0 +1,33 @@
+package com.together.buytogether.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheKeyGenerator {
+	private final ExpressionParser parser = new SpelExpressionParser();
+	private final Map<String, Expression> expressionCache = new ConcurrentHashMap<>();
+
+	public String generate(ProceedingJoinPoint joinPoint, String keyExpression, String cacheName) {
+		Expression expression = expressionCache.computeIfAbsent(keyExpression, parser::parseExpression);
+
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		String[] parameterNames = methodSignature.getParameterNames();
+		Object[] args = joinPoint.getArgs();
+		for (int i = 0; i < parameterNames.length; i++) {
+			context.setVariable(parameterNames[i], args[i]);
+		}
+
+		return cacheName + "::" + expression.getValue(context, String.class);
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/dto/SingleFlightCacheData.java
+++ b/src/main/java/com/together/buytogether/cache/dto/SingleFlightCacheData.java
@@ -1,0 +1,11 @@
+package com.together.buytogether.cache.dto;
+
+public record SingleFlightCacheData<T>(
+	T data,
+	Long decisionForUpdate,
+	Long maxAttemptRefreshCache,
+	Long createdAt,
+	Long timeToMillis
+) {
+
+}

--- a/src/main/java/com/together/buytogether/cache/singleflight/CacheState.java
+++ b/src/main/java/com/together/buytogether/cache/singleflight/CacheState.java
@@ -1,0 +1,18 @@
+package com.together.buytogether.cache.singleflight;
+
+public enum CacheState {
+	NEVER_CACHED("최초 캐시 생성"),
+	LOCAL_EXPIRED_REDIS_EXPIRED("로컬 캐시 만료, Redis 캐시 만료"),
+	LOCAL_EXPIRED_REDIS_VALID("로컬 캐시 만료, Redis 캐시 유효"),
+	LOCAL_VALID("로컬 캐시 유효");
+
+	private final String description;
+
+	CacheState(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/singleflight/CacheStrategyExecutor.java
+++ b/src/main/java/com/together/buytogether/cache/singleflight/CacheStrategyExecutor.java
@@ -1,0 +1,157 @@
+package com.together.buytogether.cache.singleflight;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.cache.Cache;
+import org.springframework.stereotype.Component;
+
+import com.together.buytogether.annotation.SingleFlightCacheable;
+import com.together.buytogether.cache.dto.SingleFlightCacheData;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CacheStrategyExecutor {
+	private static final long BASE_DELAY_MILLIS = 1000L;
+	private static final long MAX_DELAY_MILLIS = 100_000L;
+	private final SingleFlightCacheManager singleFlightCacheManager;
+
+	public CacheStrategyExecutor(SingleFlightCacheManager singleFlightCacheManager) {
+		this.singleFlightCacheManager = singleFlightCacheManager;
+	}
+
+	public Object executeCacheStrategy(SingleFlightCacheable annotation, String cacheKey,
+		ProceedingJoinPoint joinPoint) throws Throwable {
+		CacheState state = singleFlightCacheManager.determineCacheState(annotation.cacheName(), cacheKey);
+
+		return switch (state) {
+			case NEVER_CACHED -> handleNeverCached(annotation, joinPoint, cacheKey);
+			case LOCAL_EXPIRED_REDIS_EXPIRED -> handleBothExpired(cacheKey, annotation, joinPoint);
+			case LOCAL_EXPIRED_REDIS_VALID -> handleLocalExpiredOnly(cacheKey, joinPoint, annotation);
+			case LOCAL_VALID -> handleLocalValid(annotation, cacheKey);
+		};
+	}
+
+	private Object handleBothExpired(String cacheKey, SingleFlightCacheable annotation,
+		ProceedingJoinPoint joinPoint) throws Throwable {
+		if (singleFlightCacheManager.acquireLock(cacheKey)) {
+			try {
+				return recreateCacheWithLock(annotation, joinPoint, cacheKey);
+			} finally {
+				singleFlightCacheManager.releaseLock(cacheKey);
+			}
+		} else {
+			return waitForCacheCreation(cacheKey);
+		}
+	}
+
+	private Object handleLocalValid(SingleFlightCacheable annotation, String cacheKey) {
+		String cacheName = annotation.cacheName();
+		Object cachedValue = singleFlightCacheManager.getFromLocal(cacheName, cacheKey);
+		Object rawValue = (cachedValue instanceof Cache.ValueWrapper)
+			? ((Cache.ValueWrapper)cachedValue).get()
+			: cachedValue;
+
+		if (rawValue instanceof SingleFlightCacheData) {
+			return ((SingleFlightCacheData)rawValue).data();
+		}
+
+		return rawValue;
+	}
+
+	private Object handleLocalExpiredOnly(String cacheKey,
+		ProceedingJoinPoint joinPoint,
+		SingleFlightCacheable annotation) throws Throwable {
+		SingleFlightCacheData cacheData = singleFlightCacheManager.getFromRedis(cacheKey);
+
+		if (shouldRefresh(cacheData)) {
+			if (singleFlightCacheManager.acquireLock(cacheKey)) {
+				SingleFlightCacheData data = createAndExecuteBusinessLogic(annotation, joinPoint);
+				singleFlightCacheManager.storeInBothCaches(cacheKey, annotation, data);
+			}
+			return cacheData.data();
+		}
+
+		return cacheData.data();
+	}
+
+	private Object handleNeverCached(SingleFlightCacheable annotation, ProceedingJoinPoint joinPoint,
+		String cacheKey) throws Throwable {
+		SingleFlightCacheData result = createAndExecuteBusinessLogic(annotation, joinPoint);
+		singleFlightCacheManager.storeInBothCaches(cacheKey, annotation, result);
+		return result.data();
+	}
+
+	private boolean decideToUpdateCache(long createdAt, long timeToLiveMillis, long decisionForUpdate) {
+		long currentTime = System.currentTimeMillis();
+		long passedDuration = currentTime - createdAt;
+		return passedDuration >= timeToLiveMillis * (decisionForUpdate / 100.0);
+	}
+
+	private Object waitForCacheCreation(String cacheKey) throws Throwable {
+		for (int attempt = 0; attempt < 10; attempt++) {
+			SingleFlightCacheData cached = singleFlightCacheManager.getFromRedis(cacheKey);
+			if (cached != null) {
+				return cached.data();
+			}
+			backoff(attempt);
+		}
+		throw new RuntimeException("캐시 획득 실패");
+	}
+
+	private SingleFlightCacheData createAndExecuteBusinessLogic(SingleFlightCacheable annotation,
+		ProceedingJoinPoint joinPoint) throws Throwable {
+		return createSingleFlightCacheData(
+			joinPoint,
+			annotation.decisionForUpdate(),
+			annotation.maxAttemptRefreshCache(),
+			annotation.redisTimeToLiveMillis()
+		);
+	}
+
+	private void backoff(int attempt) {
+		try {
+			long delay = Math.min(
+				BASE_DELAY_MILLIS << attempt,
+				MAX_DELAY_MILLIS);
+			TimeUnit.MILLISECONDS.sleep(delay);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private SingleFlightCacheData createSingleFlightCacheData(
+		ProceedingJoinPoint joinPoint,
+		Long decisionForUpdate,
+		Long maxAttemptRefreshCache,
+		Long timeToLiveMillis) throws Throwable {
+		SingleFlightCacheData result = new SingleFlightCacheData<>(joinPoint.proceed(),
+			decisionForUpdate,
+			maxAttemptRefreshCache,
+			LocalDateTime.now().toEpochSecond(ZoneOffset.UTC),
+			timeToLiveMillis);
+		return result;
+	}
+
+	private Object recreateCacheWithLock(SingleFlightCacheable annotation,
+		ProceedingJoinPoint joinPoint,
+		String cacheKey) throws Throwable {
+		SingleFlightCacheData data = createAndExecuteBusinessLogic(annotation, joinPoint);
+		singleFlightCacheManager.storeInBothCaches(cacheKey, annotation, data);
+		return data.data();
+	}
+
+	private boolean shouldRefresh(SingleFlightCacheData cacheData) {
+		boolean hasRefreshCountLeft =
+			cacheData.maxAttemptRefreshCache() > 0 || cacheData.maxAttemptRefreshCache() == -1;
+		if (!hasRefreshCountLeft) {
+			return false;
+		}
+
+		return decideToUpdateCache(cacheData.createdAt(), cacheData.timeToMillis(), cacheData.decisionForUpdate());
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/singleflight/RedisCacheService.java
+++ b/src/main/java/com/together/buytogether/cache/singleflight/RedisCacheService.java
@@ -1,0 +1,45 @@
+package com.together.buytogether.cache.singleflight;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.together.buytogether.cache.dto.SingleFlightCacheData;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class RedisCacheService {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public RedisCacheService(RedisTemplate<String, Object> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public SingleFlightCacheData get(String key) {
+		Object value = redisTemplate.opsForValue().get(key);
+		if (value == null) {
+			return null;
+		}
+		return (SingleFlightCacheData)value;
+	}
+
+	public void put(String key, SingleFlightCacheData singleFlightCacheData, Long timeToLiveMillis) {
+		redisTemplate.opsForValue().set(key, singleFlightCacheData, Duration.ofMillis(timeToLiveMillis));
+	}
+
+	public boolean evict(String key) {
+		return redisTemplate.delete(key);
+	}
+
+	public boolean getLock(String key, Long timeToLiveMillis) {
+		Boolean result = redisTemplate.opsForValue().setIfAbsent(key, key, Duration.ofMillis(timeToLiveMillis));
+		return Boolean.TRUE.equals(result);
+	}
+
+	public void unlock(String key) {
+		redisTemplate.delete(key);
+	}
+}

--- a/src/main/java/com/together/buytogether/cache/singleflight/SingleFlightCacheManager.java
+++ b/src/main/java/com/together/buytogether/cache/singleflight/SingleFlightCacheManager.java
@@ -1,0 +1,89 @@
+package com.together.buytogether.cache.singleflight;
+
+import org.springframework.cache.Cache;
+import org.springframework.stereotype.Component;
+
+import com.together.buytogether.annotation.SingleFlightCacheable;
+import com.together.buytogether.cache.dto.SingleFlightCacheData;
+import com.together.buytogether.cache.manager.LocalCacheManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class SingleFlightCacheManager {
+	private static final Long DEFAULT_LOCK_TIMEOUT_MILLIS = 6000L;
+	private final LocalCacheManager localCacheManager;
+	private final RedisCacheService redisCacheService;
+
+	public SingleFlightCacheManager(LocalCacheManager localCacheManager, RedisCacheService redisCacheService) {
+		this.localCacheManager = localCacheManager;
+		this.redisCacheService = redisCacheService;
+	}
+
+	public CacheState determineCacheState(String cacheName, String cacheKey) {
+		if (isNeverCachedBefore(cacheName)) {
+			return CacheState.NEVER_CACHED;
+		}
+
+		if (isLocalCacheExpired(cacheName, cacheKey)) {
+			if (isRedisCacheExpired(cacheKey)) {
+				return CacheState.LOCAL_EXPIRED_REDIS_EXPIRED;
+			} else {
+				return CacheState.LOCAL_EXPIRED_REDIS_VALID;
+			}
+		}
+
+		return CacheState.LOCAL_VALID;
+	}
+
+	public void putToRedis(String key, SingleFlightCacheData singleFlightCacheData, Long timeToLiveMillis) {
+		redisCacheService.put(key, singleFlightCacheData, timeToLiveMillis);
+	}
+
+	public SingleFlightCacheData getFromRedis(String cacheKey) {
+		return redisCacheService.get(cacheKey);
+	}
+
+	public Cache.ValueWrapper getFromLocal(String cacheName, String cacheKey) {
+		return localCacheManager.getCache(cacheName).get(cacheKey);
+	}
+
+	private boolean isNeverCachedBefore(String cacheName) {
+		return localCacheManager.getCache(cacheName) == null;
+	}
+
+	private boolean isLocalCacheExpired(String cacheName, String cacheKey) {
+		Cache cache = localCacheManager.getCache(cacheName);
+		return cache.get(cacheKey) == null;
+	}
+
+	private boolean isRedisCacheExpired(String cacheKey) {
+		return redisCacheService.get(cacheKey) == null;
+	}
+
+	public boolean acquireLock(String cacheKey) {
+		String lockKey = cacheKey + "::lock";
+		return redisCacheService.getLock(lockKey, DEFAULT_LOCK_TIMEOUT_MILLIS);
+	}
+
+	public void releaseLock(String cacheKey) {
+		redisCacheService.unlock(cacheKey);
+	}
+
+	public void storeInBothCaches(String cacheKey,
+		SingleFlightCacheable annotation,
+		SingleFlightCacheData data) {
+		log.info(cacheKey);
+		redisCacheService.put(cacheKey, data, annotation.redisTimeToLiveMillis());
+		localCacheManager.putToCache(annotation.cacheName(), cacheKey, data, annotation.localTimeToLiveMillis());
+	}
+
+	public void evictFromLocal(String cacheName, String cacheKey) {
+		localCacheManager.getCache(cacheName).evict(cacheKey);
+	}
+
+	public void evictFromRedis(String cacheKey) {
+		redisCacheService.evict(cacheKey);
+	}
+}

--- a/src/main/java/com/together/buytogether/common/service/CommonPostService.java
+++ b/src/main/java/com/together/buytogether/common/service/CommonPostService.java
@@ -1,8 +1,9 @@
 package com.together.buytogether.common.service;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.together.buytogether.annotation.SingleFlightCacheable;
 import com.together.buytogether.post.domain.Post;
 import com.together.buytogether.post.domain.PostRepository;
 
@@ -14,7 +15,9 @@ public class CommonPostService {
 		this.postRepository = postRepository;
 	}
 
-	@Cacheable(key = "#postId", value = "post")
+	@SingleFlightCacheable(cacheName = "SinglePost", key = "#postId",
+		redisTimeToLiveMillis = 20000, localTimeToLiveMillis = 10000, decisionForUpdate = 70)
+	@Transactional(readOnly = true)
 	public Post getPost(Long postId) {
 		return postRepository.getByPostId(postId);
 	}


### PR DESCRIPTION
캐시된 데이터는 영원하지 않습니다. 인기 있는 캐시 키가 동시에 만료될 경우, 수많은 요청(스레드)이 한꺼번에 DB로 몰려가 시스템 전체에 심각한 부하를 주는 '캐시 스탬피드(Cache Stampede)' 현상이 발생할 수 있습니다.

이 문제를 해결하고 시스템을 안정적으로 보호하기 위해,  두 가지 상황에 맞는 전략을 적용했습니다.

1. 사전 갱신 (Proactive Cache Refresh)

이 전략은 캐시가 만료되기 전에 미리 데이터를 갱신하여, 사용자가 끊김 없이 캐시된 데이터를 사용하게 하는 방법입니다. 마치 "물이 반쯤 남았을 때 미리 채워두는" 것과 같습니다.

    동작 방식

        사용자가 캐시된 데이터(GET 호출)에 접근합니다.

        시스템은 데이터의 남은 유효 시간(TTL)을 확인합니다.

        만약 남은 TTL이 설정된 임계값(예: 전체 TTL의 10%) 미만이면, 해당 요청은 분산 락(Distributed Lock) 획득을 시도합니다.

            락 획득 성공 시: 이 요청은 DB로부터 새로운 데이터를 가져와 캐시를 미리 갱신합니다.

            락 획득 실패 시: 다른 스레드가 이미 갱신 중이라는 의미이므로, 기다리지 않고 기존의 만료되지 않은 캐시 데이터를 즉시 반환합니다.

    

2. 요청 제어 (Request Coalescing)

이 전략은 캐시가 이미 만료된 후에 여러 요청이 동시에 DB로 몰리는 것을 막는 방법입니다. 대표 선수 한 명만 DB에 접근하도록 하고, 나머지는 그 선수가 돌아올 때까지 잠시 기다리게 하는 방식입니다.

    동작 방식

        캐시가 만료된 것을 확인한 여러 요청이 동시에 들어옵니다.

        이 중 단 하나의 요청만 분산 락을 획득하고 DB에 데이터 조회를 요청합니다.

        락을 얻지 못한 나머지 요청들은 DB에 접근하지 않고, 잠시 대기합니다. (예: sleep 또는 backoff 전략 사용)

        락을 획득했던 요청이 DB에서 가져온 데이터로 캐시를 갱신하고 락을 해제합니다.

        기다리던 나머지 요청들은 이제 새롭게 캐시된 데이터를 읽어 반환합니다.

  