### PR TITLE
fix: Gradle 빌드를 깨뜨리는 미사용 애너테이션 제거

### DIFF
--- a/src/main/java/com/together/buytogether/enroll/service/EnrollFacade.java
+++ b/src/main/java/com/together/buytogether/enroll/service/EnrollFacade.java
@@ -4,7 +4,6 @@ import static com.together.buytogether.common.lock.LockNumberConstants.*;
 
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import com.together.buytogether.common.lock.DistributedLockFacade;
@@ -25,7 +24,7 @@ public class EnrollFacade {
 		this.distributedLockFacade = distributedLockFacade;
 	}
 
-	public ResponseDTO<JoinEnrollResponseDTO> joinBuying(Long memberId, @NotNull JoinEnrollDTO joinEnrollDTO) {
+	public ResponseDTO<JoinEnrollResponseDTO> joinBuying(Long memberId, JoinEnrollDTO joinEnrollDTO) {
 		return distributedLockFacade.executeWithLock("enroll_lock_" + joinEnrollDTO.productId(),
 			LOCK_WAIT_MILLI_SECOND,
 			LOCK_LEASE_MILLI_SECOND,

--- a/src/test/java/com/together/buytogether/post/service/PostLikeSyncAsyncTest.java
+++ b/src/test/java/com/together/buytogether/post/service/PostLikeSyncAsyncTest.java
@@ -22,9 +22,6 @@ import com.together.buytogether.post.domain.Post;
 import com.together.buytogether.post.domain.PostLikeRepository;
 import com.together.buytogether.post.domain.PostRepository;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @SpringBootTest
 public class PostLikeSyncAsyncTest {
 


### PR DESCRIPTION
## 변경 사항

- `EnrollFacade`에서 Gradle 클래스패스에 없는 `org.jetbrains.annotations.NotNull` import와 미사용 애너테이션을 제거했습니다.
- `PostLikeSyncAsyncTest`에서 사용되지 않으며 테스트 클래스패스에 없는 Lombok `@Slf4j` 애너테이션을 제거했습니다.

## 변경 이유

IntelliJ에서는 인식되지만 Gradle 빌드에서는 제공되지 않는 애너테이션 때문에 컴파일이 실패할 수 있었습니다. 두 애너테이션 모두 실제 검증·로깅 동작에 사용되지 않아 제거했습니다.

## 영향

런타임 비즈니스 로직과 요청 검증 동작에는 영향이 없습니다.

## 검증

- `./gradlew clean compileTestJava`
